### PR TITLE
implicit utf8 encoding on html read/write

### DIFF
--- a/dashit.py
+++ b/dashit.py
@@ -123,13 +123,15 @@ if __name__ == '__main__':
             indexs = list()
             try:
                 assert filepath.endswith('.html')
-                soup = BeautifulSoup(open(filepath), 'lxml')
-                for index in extract_cppmodule(soup):
-                    indexs.append(index)
-                for index in extract_sectionlink(soup):
-                    indexs.append(index)
-                remove_navbar(soup)
-                open(dstpath, 'w').write(str(soup))
+                with open(filepath, 'rb') as src:
+                    soup = BeautifulSoup(src.read().decode('utf8'), 'lxml')
+                    for index in extract_cppmodule(soup):
+                        indexs.append(index)
+                    for index in extract_sectionlink(soup):
+                        indexs.append(index)
+                    remove_navbar(soup)
+                    with open(dstpath, 'wb') as dst:
+                        dst.write(soup.encode('utf8'))
             except AssertionError:
                 # except:
                 shutil.copy(filepath, dstpath)


### PR DESCRIPTION
Otherwise for some reason on Python 3.6 (Conda) io.read defaults to
cp1252 causing an exception:

UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position
41217: character maps to <undefined>

@blahgeek Btw. thanks for awesome CUDA doc import 👍 , I am using it on Windows with Zeal now. (I used to work with Dash too)